### PR TITLE
Bump Datadog buildpack to version 4.36.0

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -11,7 +11,7 @@ fi
 
 RESOURCES_DIR="tile/resources"
 
-BUILDPACK_VERSION=4.35.1
+BUILDPACK_VERSION=4.36.0
 
 major=$(echo $BUILDPACK_VERSION | cut -d. -f1)
 minor=$(echo $BUILDPACK_VERSION | cut -d. -f2)

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -9,5 +9,5 @@ apply_open_security_group: false
 packages:
 - name: datadog-application-monitoring
   type: buildpack
-  path: resources/datadog-cloudfoundry-buildpack.zip
+  path: resources/datadog-cloudfoundry-buildpack-4.36.0.zip
   buildpack_order: 99


### PR DESCRIPTION
Starting from 4.36.0 the buildpack zip file has a version suffix. See [Release 4.36.0](https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/tag/4.36.0)
