### PR TITLE
Remove buildpack version suffix

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -13,16 +13,7 @@ RESOURCES_DIR="tile/resources"
 
 BUILDPACK_VERSION=4.36.0
 
-major=$(echo $BUILDPACK_VERSION | cut -d. -f1)
-minor=$(echo $BUILDPACK_VERSION | cut -d. -f2)
+BUILDPACK_NAME=datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip
 
-if [ $major -gt 4 ] || [ $major -eq 4 -a $minor -ge 36 ]; then
-    echo "download datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip"
-    curl -L "https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/download/$BUILDPACK_VERSION/datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip" -o $RESOURCES_DIR/datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip
-
-    echo "update tile.yml resource path"
-    sed -i -e "s/path:.*/path: resources\/datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip/g" tile/tile.yml
-else
-    echo "download datadog-cloudfoundry-buildpack.zip"
-    curl -L "https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/download/$BUILDPACK_VERSION/datadog-cloudfoundry-buildpack.zip" -o $RESOURCES_DIR/datadog-cloudfoundry-buildpack.zip
-fi
+echo "download $BUILDPACK_NAME"
+curl -L "https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/download/$BUILDPACK_VERSION/$BUILDPACK_NAME" -o $RESOURCES_DIR/datadog-cloudfoundry-buildpack.zip

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -9,5 +9,5 @@ apply_open_security_group: false
 packages:
 - name: datadog-application-monitoring
   type: buildpack
-  path: resources/datadog-cloudfoundry-buildpack-4.36.0.zip
+  path: resources/datadog-cloudfoundry-buildpack.zip
   buildpack_order: 99


### PR DESCRIPTION
Removes the buildpack version suffix as it causes errors during the `deploy-all` errand tests that automatically attach the tile version as a suffix.