### PR TITLE
Upgrade tile to `ubuntu-jammy` stemcells

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -6,6 +6,11 @@ description: Send application metrics, logs and traces to Datadog!
 
 apply_open_security_group: false
 
+stemcell_criteria:
+  os: ubuntu-jammy
+  requires_cpi: false
+  version: '1'
+
 packages:
 - name: datadog-application-monitoring
   type: buildpack


### PR DESCRIPTION
Note: The 4.36.0 buildpack only supports `cflinuxfs3` and `cflinuxfs4-compat` stack for now.