### PR TITLE
Remove `bpm-release`

### DIFF
--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -12,12 +12,7 @@ fi
 RESOURCES_DIR="tile/resources"
 
 BUILDPACK_VERSION=4.38.0
-BPM_VERSION=1.2.7
-
 BUILDPACK_NAME=datadog-cloudfoundry-buildpack-$BUILDPACK_VERSION.zip
 
 echo "download $BUILDPACK_NAME"
 curl -L "https://github.com/DataDog/datadog-cloudfoundry-buildpack/releases/download/$BUILDPACK_VERSION/$BUILDPACK_NAME" -o $RESOURCES_DIR/datadog-cloudfoundry-buildpack.zip
-
-echo "download bpm-release $BPM_VERSION"
-curl -L "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=$BPM_VERSION" -o $RESOURCES_DIR/bpm-release.tgz

--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -16,21 +16,3 @@ packages:
   type: buildpack
   path: resources/datadog-cloudfoundry-buildpack.zip
   buildpack_order: 99
-- name: bpm
-  type: bosh-release
-  path: resources/bpm-release.tgz
-
-runtime_configs:
-- name: datadog-application-monitoring
-  runtime_config:
-    releases:
-    - name: bpm
-      version: "1.2.7"
-    addons:
-    - name: datadog-application-monitoring-bpm
-      include:
-        deployments:
-          - (( ..datadog-application-monitoring.deployment_name ))
-      jobs:
-      - name: bpm
-        release: bpm


### PR DESCRIPTION
We no longer ship `bpm` within the cluster monitoring tile. Shipping `bpm` in this tile is no longer needed.

See https://github.com/DataDog/datadog-cluster-monitoring-pivotal-tile/pull/117