### PR TITLE
Replace invalid team platform-integrations with agent-integrations in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 # and another team can own the rest of the directory.
 
 # All your base
-*                       @DataDog/platform-integrations
+*                       @DataDog/agent-integrations
 
 # Documentation
-*.md                    @DataDog/platform-integrations
+*.md                    @DataDog/agent-integrations


### PR DESCRIPTION
## Summary

Replaces `@DataDog/platform-integrations` (team not found in org) with `@DataDog/agent-integrations` in `.github/CODEOWNERS`.

Affects `*` catch-all and `*.md` patterns.

Part of org-wide CODEOWNERS cleanup sweep tracked by Source Code Management team.